### PR TITLE
Change systemd startscript

### DIFF
--- a/misc/System Config/homegear-gateway.service
+++ b/misc/System Config/homegear-gateway.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Homegear Gateway
-After=homegear
+After=network.target
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The gateway won't start automatically if homegear is not installed.