### PR TITLE
Attempt to fix "Module MAX: Warning: Packet with wrong length byte received."

### DIFF
--- a/src/Families/MaxCc1101.cpp
+++ b/src/Families/MaxCc1101.cpp
@@ -193,6 +193,7 @@ void MaxCc1101::mainThread()
                         {
                             uint8_t firstByte = readRegister(Registers::Enum::FIFO);
                             std::vector<uint8_t> packetBytes = readRegisters(Registers::Enum::FIFO, firstByte + 1); //Read packet + RSSI
+                            packetBytes[0] = firstByte;
                             if(packetBytes.size() > 100)
                             {
                                 if(!_firstPacket)


### PR DESCRIPTION
Fixes: #5

Untested but worth a try to see if this resolves it. I think I am the only one using MAX! with Homegear-Gateway anyways as nobody noticed that it was completely broken until my first fix....