### PR TITLE
Remove useless instruction

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -225,7 +225,6 @@ void Settings::load(std::string filename, std::string executablePath)
 				{
 					_secureMemorySize = BaseLib::Math::getNumber(value);
 					//Allow 0 => disable secure memory. 16384 is minimum size. Values smaller than 16384 are set to 16384 by gcrypt: https://gnupg.org/documentation/manuals/gcrypt-devel/Controlling-the-library.html
-					if(_secureMemorySize < 0) _secureMemorySize = 1;
 					Gd::bl->out.printDebug("Debug: secureMemorySize set to " + std::to_string(_secureMemorySize));
 				}
 				else if(name == "cafile")


### PR DESCRIPTION
_secureMemorySize is unsigned, so it will never be negative